### PR TITLE
Allow user to persist generated files

### DIFF
--- a/cmd/ugo/main.go
+++ b/cmd/ugo/main.go
@@ -31,6 +31,7 @@ func main() {
 		AddFlag("recursive,r,R", "recursively look for tutorials", commando.Bool, false).
 		AddFlag("verbose,v", "verbose output", commando.Bool, false).
 		AddFlag("extensions,e", "comma separated list of tutorial file extensions", commando.String, ".md,.mdx").
+		AddFlag("keep,k", "keep the generated files", commando.Bool, false).
 		SetAction(func(args cliArgs, flags cliFlags) {
 			logger := &ugo.Logger{
 				Level: ugo.INFO,
@@ -60,6 +61,11 @@ func main() {
 				fatalError(logger, err, 1)
 			}
 			extensions := strings.Split(extList, ",")
+
+			keep, err := flags["keep"].GetBool()
+			if err != nil {
+				fatalError(logger, err, 1)
+			}
 
 			files, err := searchForFiles(path, recursive, extensions)
 			if err != nil {
@@ -92,7 +98,7 @@ func main() {
 				return
 			}
 
-			err = ugo.Invoke(logger, ugo.Aggregate(plans...))
+			_, err = ugo.Invoke(logger, keep, ugo.Aggregate(plans...))
 			if err != nil {
 				fatalError(logger, err, 3)
 			}

--- a/pkg/ugo/internal/invokers/assert.go
+++ b/pkg/ugo/internal/invokers/assert.go
@@ -27,7 +27,7 @@ func (a *AssertInvoker) Supports(task types.Task) bool {
 	return ok
 }
 
-func (a *AssertInvoker) Invoke(task types.Task, _, prevOutput string) (output string, err error) {
+func (a *AssertInvoker) Invoke(task types.Task, keep bool, _, prevOutput string) (output string, err error) {
 	containsTask := task.(*tasks.AssertContainsTask)
 	return "", a.executeAssertContains(prevOutput, containsTask)
 }

--- a/pkg/ugo/internal/invokers/assert_test.go
+++ b/pkg/ugo/internal/invokers/assert_test.go
@@ -27,7 +27,7 @@ line 5...
 					tasks.WithIgnoreLines("..."))
 
 				assert.True(t, invoker.Supports(assertContainsTask))
-				_, err := invoker.Invoke(assertContainsTask, "", `line 1
+				_, err := invoker.Invoke(assertContainsTask, false, "", `line 1
 line 2
 line 3
 ...line 4
@@ -46,7 +46,7 @@ line 3...
 					tasks.WithIgnoreLines("..."))
 
 				assert.True(t, invoker.Supports(assertContainsTask))
-				_, err := invoker.Invoke(assertContainsTask, "", `line 1
+				_, err := invoker.Invoke(assertContainsTask, false, "", `line 1
 line 2
 line 3`)
 
@@ -65,7 +65,7 @@ a url http://example.com/
 					tasks.WithIgnoreLines("..."))
 
 				assert.True(t, invoker.Supports(assertContainsTask))
-				_, err := invoker.Invoke(assertContainsTask, "", `line 1
+				_, err := invoker.Invoke(assertContainsTask, false, "", `line 1
 line 2
 [something] with brackers
 a line in the middle

--- a/pkg/ugo/internal/invokers/exec.go
+++ b/pkg/ugo/internal/invokers/exec.go
@@ -28,13 +28,15 @@ func (e *ExecInvoker) Supports(task types.Task) bool {
 	return ok
 }
 
-func (e *ExecInvoker) Invoke(task types.Task, workDir, _ string) (output string, err error) {
-	return e.executeExec(workDir, task.(*tasks.ExecTask))
+func (e *ExecInvoker) Invoke(task types.Task, keep bool, workDir, _ string) (output string, err error) {
+	return e.executeExec(keep, workDir, task.(*tasks.ExecTask))
 }
 
-func (e *ExecInvoker) executeExec(workDir string, task *tasks.ExecTask) (output string, err error) {
+func (e *ExecInvoker) executeExec(keep bool, workDir string, task *tasks.ExecTask) (output string, err error) {
 	tmpScript := filepath.Join(workDir, fmt.Sprintf(".script-%x", sha256.Sum256([]byte(task.Contents()))))
-	defer os.Remove(tmpScript)
+	if !keep {
+		defer os.Remove(tmpScript)
+	}
 
 	exitCode := task.ExitCode()
 

--- a/pkg/ugo/internal/invokers/file.go
+++ b/pkg/ugo/internal/invokers/file.go
@@ -28,7 +28,7 @@ func (f *FileInvoker) Supports(task types.Task) bool {
 	return ok
 }
 
-func (f *FileInvoker) Invoke(task types.Task, workDir, _ string) (output string, err error) {
+func (f *FileInvoker) Invoke(task types.Task, keep bool, workDir, _ string) (output string, err error) {
 	return "", f.executeFile(workDir, task.(*tasks.FileTask))
 }
 

--- a/pkg/ugo/types/invoker.go
+++ b/pkg/ugo/types/invoker.go
@@ -2,5 +2,5 @@ package types
 
 type Invoker interface {
 	Supports(task Task) bool
-	Invoke(task Task, workDir, prevOutput string) (output string, err error)
+	Invoke(task Task, keep bool, workDir, prevOutput string) (output string, err error)
 }


### PR DESCRIPTION
Allowing users the option of keeping generated files makes it easier to debug incremental examples.  Should a test fail, the user can examine the generated output to diagnose the issue.